### PR TITLE
Fix bug with bytes_per_second field of status json

### DIFF
--- a/status.go
+++ b/status.go
@@ -366,18 +366,18 @@ type FdbStatus struct {
 			Valid  bool `json:"_valid"`
 			Backup struct {
 				BlobRecentIo struct {
-					BytesPerSecond     int64 `json:"bytes_per_second"`
-					BytesSent          int64 `json:"bytes_sent"`
-					RequestsFailed     int64 `json:"requests_failed"`
-					RequestsSuccessful int64 `json:"requests_successful"`
+					BytesPerSecond     float64 `json:"bytes_per_second"`
+					BytesSent          int64   `json:"bytes_sent"`
+					RequestsFailed     int64   `json:"requests_failed"`
+					RequestsSuccessful int64   `json:"requests_successful"`
 				} `json:"blob_recent_io"`
 				Instances map[string]struct {
 					BlobStats struct {
 						Recent struct {
-							BytesPerSecond     int64 `json:"bytes_per_second"`
-							BytesSent          int64 `json:"bytes_sent"`
-							RequestsFailed     int64 `json:"requests_failed"`
-							RequestsSuccessful int64 `json:"requests_successful"`
+							BytesPerSecond     float64 `json:"bytes_per_second"`
+							BytesSent          int64   `json:"bytes_sent"`
+							RequestsFailed     int64   `json:"requests_failed"`
+							RequestsSuccessful int64   `json:"requests_successful"`
 						} `json:"recent"`
 						Total struct {
 							BytesSent          int64 `json:"bytes_sent"`


### PR DESCRIPTION
While using FoundationDB with the backup feature enabled, I noticed that `fdbtop` does not work properly.

I verified that the `bytes_per_second` field, which represents the rate of data backup, is a floating-point number. ([source](https://github.com/apple/foundationdb/blob/7.1.40/fdbbackup/backup.actor.cpp#L1588))
